### PR TITLE
Add SOQuartz USB host

### DIFF
--- a/soquartz/soquartz-cm4-usb-host.dts
+++ b/soquartz/soquartz-cm4-usb-host.dts
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: MIT */
+
+/* This example enables USB host on SOQuartz connected to CM4-IO carrier */
+
+/dts-v1/;
+/plugin/;
+
+&usb2phy0_host {
+	phy-supply = <&vcc_5v>;
+	status = "okay";
+};
+
+&usb_host0_xhci {
+	dr_mode = "host";
+	status = "okay";
+};


### PR DESCRIPTION
Thank you for amazing work on Plebian!

I've been trying it out SOQuartz connected to CM4-IO (actually to WaveShare CM4-IO-BASE A, but they seem identical), and discovered that USB host doesn't work.

This overlay solves it.